### PR TITLE
Update getgfs.py problem with casting from list to float fixed.

### DIFF
--- a/getgfs/getgfs.py
+++ b/getgfs/getgfs.py
@@ -256,8 +256,8 @@ class Forecast:
         """
         if isinstance(inpt, str):
             if inpt[0] == "[" and inpt[-1] == "]" and ":" in inpt:
-                val_1 = float(re.findall(r"\[(.*?):", inpt))
-                val_2 = float(re.findall(r"\:(.*?)]", inpt))
+                val_1 = float(re.findall(r"\[(.*?):", inpt)[0])
+                val_2 = float(re.findall(r"\:(.*?)]", inpt)[0])
                 val_min = self.value_to_index(coord, min(val_1, val_2))
                 val_max = self.value_to_index(coord, max(val_1, val_2))
                 ind = "[%s:%s]" % (val_min, val_max)


### PR DESCRIPTION
There was a problem with casting lat and long input from string to float which it was not a string, it was a list containing string. It is now fixed by getting list's first element and then cast it to float.
you can now use range in type of "[70.1:70.2]" for lat and long.