### PR TITLE
Fix improper query time when query and forecast timedelta is larger than one day

### DIFF
--- a/getgfs/getgfs.py
+++ b/getgfs/getgfs.py
@@ -245,7 +245,7 @@ class Forecast:
 
             query_time = "[{t_ind}]".format(
                 t_ind=round(
-                    (desired_date - query_forecast).seconds
+                    (desired_date - query_forecast).total_seconds()
                     / (int(self.times["grads_step"][0]) * 60 * 60)
                 )
             )


### PR DESCRIPTION
the `timedelta.seconds` property is unreliable when timedeltas are larger than 24hrs (see [here](https://stackoverflow.com/questions/51652952/python-timedelta-seconds-vs-total-seconds)) 

PR replaces this with `timedelta.total_seconds()` to get the true value.

This may fix #8 . 

Thanks for building this great utility!